### PR TITLE
Remove direct dependencies on IBM Dump and Oracle Attach APIs

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-NMON Visualizer is a Java GUI tool for analyzing NMON system files from both AIX and Linux. It also parses IOStat files, IBM verbose GC logs, ESXTop CSV data and JSON data.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# NMON Visualizer
+
+NMON Visualizer is a Java GUI tool for analyzing NMON system files from both AIX and Linux. It also parses IOStat files, IBM verbose GC logs, ESXTop CSV data and JSON data.
+
+## Build from Source
+
+1. Download [Apache Ant](http://ant.apache.org/bindownload.cgi) and unpack into a directory, which we'll refer to as ${ANT_HOME}
+2. From the root directory of nmonvisualizer, run ${ANT_HOME}/bin/ant


### PR DESCRIPTION
I just used this tool for the first time based on someone's recommendation, and it was absolutely wonderful! Thank you so much.

I found building it slightly confusing because it depends on both the IBM Dump API and Oracle Attach APIs, which means one would need to use the IBM JDK to compile and and reference the Oracle tools.jar. This pull request simplifies this by just calling these methods through reflection. I also changed README to a markdown file and added instructions on how to compile from source.
