### PR TITLE
Add GitHub Actions on push and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       # https://docs.github.com/en/rest/releases/assets#upload-a-release-asset
       - name: Create release and upload assets
         run: |
+          FILE="NMONVisualizer_$(date +%Y-%m-%d).jar" && \
           RELEASE="$(curl \
                        --silent \
                        --show-error \
@@ -30,8 +31,8 @@ jobs:
             --show-error \
             --fail \
             --request POST \
-            --url https://uploads.github.com/repos/${{github.repository}}/releases/${RELEASE}/assets?name=NMONVisualizer_${{github.ref_name}}.jar \
+            --url https://uploads.github.com/repos/${{github.repository}}/releases/${RELEASE}/assets?name=${FILE} \
             --header "Accept: application/vnd.github.v3+json" \
-            --header "Content-Type: $(file -b --mime-type NMONVisualizer.jar)" \
+            --header "Content-Type: $(file -b --mime-type ${FILE})" \
             --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            --data-binary @NMONVisualizer.jar
+            --data-binary @${FILE}

--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,6 @@
 								<copy
 									file="${project.build.directory}/${project.build.finalName}.jar"
 									tofile="${basedir}/${project.build.finalName}.jar" />
-								<copy
-									file="${project.build.directory}/${project.build.finalName}.jar"
-									tofile="${basedir}/${project.artifactId}.jar" />
 							</target>
 						</configuration>
 					</execution>


### PR DESCRIPTION
It'd be nice to get a new release out with the ALLPROCESSES enhancement and I've previously created the following GitHub Actions for other projects that make it easier to create releases, so I thought I'd share for consideration.

Creating a release is as simple as:

```
git tag -m "$(date +"%Y-%m-%d")" -m "Description of major changes" $(date +"%Y-%m-%d")
git push --tags
```